### PR TITLE
fix: update dashboard links in documentation

### DIFF
--- a/docs/advanced-usage.html
+++ b/docs/advanced-usage.html
@@ -36,7 +36,7 @@
           <li><a href="reference.html">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -34,7 +34,7 @@
           <li><a href="reference.html">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,7 +34,7 @@
           <li><a href="reference.html">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -34,7 +34,7 @@
           <li><a href="reference.html" class="active">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/docs/report-features.html
+++ b/docs/report-features.html
@@ -36,7 +36,7 @@
           <li><a href="reference.html">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"

--- a/docs/reporters-scripts.html
+++ b/docs/reporters-scripts.html
@@ -38,7 +38,7 @@
           <li><a href="reference.html">Reference</a></li>
           <li>
             <a
-              href="https://postman-test-bit.github.io/pulse-dashboard/"
+              href="https://arghajit47.github.io/playwright-pulse-dashboard/"
               class="external-link"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
Changed links from the old Postman dashboard to the new Playwright Pulse dashboard for consistency and accuracy.