### PR TITLE
docs: update footer link in pulse email summary HTML

### DIFF
--- a/docs/pulse-report/pulse-email-summary.html
+++ b/docs/pulse-report/pulse-email-summary.html
@@ -2341,7 +2341,7 @@
         <footer class="report-footer">
             <div style="display: inline-flex; align-items: center; gap: 0.5rem;">
                 <span>Created for</span>
-                <a href="https://playwright-pulse-report.netlify.app/" target="_blank" rel="noopener noreferrer">
+                <a href="https://arghajit47.github.io/playwright-pulse/" target="_blank" rel="noopener noreferrer">
                     Pulse Email Report
                 </a>
             </div>


### PR DESCRIPTION
The link in the footer was pointing to the old Netlify app URL. Update it to point to the correct GitHub Pages URL for the Pulse Email Report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external links in the Pulse Email Report documentation to reference the current endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->